### PR TITLE
Migrate filesystem package out of utils package

### DIFF
--- a/internal/commands/init/init.go
+++ b/internal/commands/init/init.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/renegumroad/gum-cli/assets"
+	"github.com/renegumroad/gum-cli/internal/filesystem"
 	"github.com/renegumroad/gum-cli/internal/log"
 	"github.com/renegumroad/gum-cli/internal/shellmanager"
-	"github.com/renegumroad/gum-cli/internal/utils/filesystem"
 	"github.com/renegumroad/gum-cli/internal/utils/systeminfo"
 )
 
@@ -101,7 +101,7 @@ func (cmd *InitImpl) Run() error {
 
 func (cmd *InitImpl) setup() error {
 	if homeDir, err := os.UserHomeDir(); err != nil {
-		return errors.Errorf("Unable to get home directory: %s", err)
+		return err
 	} else {
 		cmd.homeDir = homeDir
 		cmd.gumHomePath = filepath.Join(homeDir, ".gum")
@@ -116,7 +116,7 @@ func (cmd *InitImpl) setup() error {
 func (cmd *InitImpl) createGumHomeDir() error {
 	if !cmd.fs.Exists(cmd.gumHomePath) {
 		log.Debugln("Creating .gum directory in home directory")
-		if err := os.Mkdir(cmd.gumHomePath, os.ModePerm); err != nil {
+		if err := cmd.fs.MkdirAll(cmd.gumHomePath); err != nil {
 			return errors.Errorf("Unable to create .gum directory in home directory: %s", err)
 		}
 	}
@@ -125,18 +125,11 @@ func (cmd *InitImpl) createGumHomeDir() error {
 }
 
 func (cmd *InitImpl) createOptGumroadDirs() error {
-	if !cmd.fs.Exists(cmd.gumroadPath) {
-		log.Debugf("Creating %s directory", cmd.gumroadPath)
-		if err := os.Mkdir(cmd.gumroadPath, os.ModePerm); err != nil {
-			return errors.Errorf("Unable to create %s directory: %s", cmd.gumroadPath, err)
-		}
-	}
-
 	cmd.gumroadBinPath = filepath.Join(cmd.gumroadPath, "bin")
 
 	if !cmd.fs.Exists(cmd.gumroadBinPath) {
 		log.Debugf("Creating %s directory", cmd.gumroadBinPath)
-		if err := os.Mkdir(cmd.gumroadBinPath, os.ModePerm); err != nil {
+		if err := cmd.fs.MkdirAll(cmd.gumroadBinPath); err != nil {
 			return errors.Errorf("Unable to create %s directory: %s", cmd.gumroadBinPath, err)
 		}
 	}

--- a/internal/filesystem/filesystem_test.go
+++ b/internal/filesystem/filesystem_test.go
@@ -303,6 +303,73 @@ func (s *filesystemSuite) TestIsExecutableWithDirectory() {
 	s.Require().True(c.IsExecutable(tmpDir))
 }
 
+func (s *filesystemSuite) TestMkdirAllWithValidPath() {
+	c := New()
+	tempDir, err := c.CreateTempDir()
+	s.Require().NoError(err)
+	defer os.RemoveAll(tempDir)
+
+	targetDir := filepath.Join(tempDir, "testdir")
+	err = c.MkdirAll(targetDir)
+	s.Require().NoError(err)
+
+	_, err = os.Stat(targetDir)
+	s.Require().NoError(err)
+}
+
+func (s *filesystemSuite) TestMkdirAllWithExistingDirectory() {
+	c := New()
+	tempDir, err := c.CreateTempDir()
+	s.Require().NoError(err)
+	defer os.RemoveAll(tempDir)
+
+	existingDir := filepath.Join(tempDir, "existingdir")
+	err = os.Mkdir(existingDir, 0755)
+	s.Require().NoError(err)
+
+	err = c.MkdirAll(existingDir)
+	s.Require().NoError(err)
+
+	_, err = os.Stat(existingDir)
+	s.Require().NoError(err)
+}
+
+func (s *filesystemSuite) TestMkdirAllWithNestedDirectories() {
+	c := New()
+	tempDir, err := c.CreateTempDir()
+	s.Require().NoError(err)
+	defer os.RemoveAll(tempDir)
+
+	nestedDir := filepath.Join(tempDir, "nested", "dir")
+	err = c.MkdirAll(nestedDir)
+	s.Require().NoError(err)
+
+	_, err = os.Stat(nestedDir)
+	s.Require().NoError(err)
+}
+
+func (s *filesystemSuite) TestMkdirAllWithInvalidPath() {
+	c := New()
+	invalidPath := "/\000/invalid"
+
+	err := c.MkdirAll(invalidPath)
+	s.Require().Error(err)
+}
+
+func (s *filesystemSuite) TestMkdirAllWithFileAsPath() {
+	c := New()
+	tempDir, err := c.CreateTempDir()
+	s.Require().NoError(err)
+	defer os.RemoveAll(tempDir)
+
+	filePath := filepath.Join(tempDir, "file")
+	_, err = os.Create(filePath)
+	s.Require().NoError(err)
+
+	err = c.MkdirAll(filePath)
+	s.Require().Error(err)
+}
+
 func TestFileSystemSuite(t *testing.T) {
 	suite.Run(t, new(filesystemSuite))
 }

--- a/internal/shellmanager/shellmanager.go
+++ b/internal/shellmanager/shellmanager.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/renegumroad/gum-cli/internal/utils/filesystem"
+	"github.com/renegumroad/gum-cli/internal/filesystem"
 )
 
 type ShellType string

--- a/internal/shellmanager/shellmanager_test.go
+++ b/internal/shellmanager/shellmanager_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/renegumroad/gum-cli/internal/utils/filesystem"
+	"github.com/renegumroad/gum-cli/internal/filesystem"
 	"github.com/stretchr/testify/suite"
 )
 


### PR DESCRIPTION
## Description

Extracts the `filesystem` package out of utils to be a top-level internal package. `utils` should be left only as a collection of functions that don't have a proper package to be part of

## Other Changes

- Adds new `MkdirAll` function and tests
- Use `MkdirAll` function to simplify `createOptGumroadDirs` function