### PR TITLE
Parse and validate gum config as part of dev up command

### DIFF
--- a/cmd/dev/dev.go
+++ b/cmd/dev/dev.go
@@ -1,0 +1,17 @@
+package dev
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func Cmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "dev",
+		Short:   "commands for development",
+		Aliases: []string{"d", "development"},
+	}
+
+	cmd.AddCommand(newUpCmd())
+
+	return cmd
+}

--- a/cmd/dev/up.go
+++ b/cmd/dev/up.go
@@ -1,0 +1,31 @@
+package dev
+
+import (
+	"github.com/renegumroad/gum-cli/internal/commands/dev"
+	"github.com/renegumroad/gum-cli/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func newUpCmd() *cobra.Command {
+	impl := dev.NewUp()
+
+	cmd := &cobra.Command{
+		Use:   "up",
+		Short: "configures your development dependencies.",
+		Long: `Configures development dependencies declared in the gum.yml file in the current directory.
+
+It will also make sure that some basic infrastructure components are already in place
+    `,
+		Example: `  # Configure the default dev environment for the project
+  gum dev up
+`,
+		PreRun: func(_ *cobra.Command, _ []string) {
+			utils.CheckFatalError(impl.Validate())
+		},
+		Run: func(_ *cobra.Command, _ []string) {
+			utils.CheckFatalError(impl.Run())
+		},
+	}
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/renegumroad/gum-cli/cmd/dev"
 	initCmd "github.com/renegumroad/gum-cli/cmd/init"
 	"github.com/renegumroad/gum-cli/internal/log"
 	"github.com/renegumroad/gum-cli/internal/version"
@@ -31,6 +32,7 @@ func rootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().StringVar(&rootFlags.LogLevel, "log-level", "info", "set log level")
 
 	rootCmd.AddCommand(initCmd.Cmd())
+	rootCmd.AddCommand(dev.Cmd())
 
 	return rootCmd
 }

--- a/gum.yml
+++ b/gum.yml
@@ -1,0 +1,6 @@
+up:
+  - brew:
+    - name: go
+    - name: goreleaser
+    - name: golangci-lint
+    - name: go-task

--- a/internal/actions/action.go
+++ b/internal/actions/action.go
@@ -1,0 +1,10 @@
+package actions
+
+type Action interface {
+}
+
+var actions = map[string]Action{}
+
+func Exists(name string) bool {
+	return actions[name] != nil
+}

--- a/internal/commands/dev/up.go
+++ b/internal/commands/dev/up.go
@@ -1,0 +1,39 @@
+package dev
+
+import (
+	"github.com/renegumroad/gum-cli/internal/filesystem"
+	"github.com/renegumroad/gum-cli/internal/gumconfig"
+)
+
+type UpImpl struct {
+	fs     filesystem.Client
+	config *gumconfig.GumConfig
+}
+
+func NewUp() *UpImpl {
+	return newUpWithComponents(filesystem.New())
+}
+
+func newUpWithComponents(fs filesystem.Client) *UpImpl {
+	return &UpImpl{
+		fs: fs,
+	}
+}
+
+func (impl *UpImpl) Validate() error {
+	currentDir, err := impl.fs.CurrentDir()
+	if err != nil {
+		return err
+	}
+
+	impl.config, err = gumconfig.New(currentDir)
+	if err != nil {
+		return err
+	}
+
+	return impl.config.Validate()
+}
+
+func (impl *UpImpl) Run() error {
+	return nil
+}

--- a/internal/gumconfig/config.go
+++ b/internal/gumconfig/config.go
@@ -1,0 +1,94 @@
+package gumconfig
+
+import (
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/renegumroad/gum-cli/internal/actions"
+	"github.com/renegumroad/gum-cli/internal/filesystem"
+	"github.com/renegumroad/gum-cli/internal/homebrew"
+	"github.com/renegumroad/gum-cli/internal/log"
+	"github.com/renegumroad/gum-cli/internal/yaml"
+)
+
+var (
+	configFileNameOptions = []string{
+		"gum.yml",
+		"gum.yaml",
+	}
+)
+
+type GumConfig struct {
+	Up []UpAction `yaml:"up,omitempty"`
+}
+
+type UpAction struct {
+	Action NamedAction        `yaml:"action,omitempty"`
+	Brew   []homebrew.Package `yaml:"brew,omitempty"`
+}
+
+type NamedAction string
+
+func New(dir string) (*GumConfig, error) {
+	config, err := findConfig(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func (config *GumConfig) Validate() error {
+	log.Debugf("Validating gum config")
+
+	for _, up := range config.Up {
+		if up.Action == "" && len(up.Brew) == 0 {
+			return errors.Errorf("Named action or brew packages are required")
+		} else if up.Action != "" && len(up.Brew) > 0 {
+			return errors.Errorf("Cannot defined a named action and brew packages in the same entry")
+		}
+
+		if up.Action != "" {
+			if !actions.Exists(string(up.Action)) {
+				return errors.Errorf("Named action %s does not exist", up.Action)
+			}
+		}
+
+		for _, pkg := range up.Brew {
+			if pkg.Name == "" {
+				return errors.Errorf("Package name is required")
+			}
+		}
+
+	}
+
+	log.Infoln("gum config validated successfully")
+	return nil
+}
+
+func findConfig(dir string) (*GumConfig, error) {
+	log.Debugf("Detecting gum config in %s", dir)
+	fs := filesystem.New()
+	for _, fileName := range configFileNameOptions {
+		path := filepath.Join(dir, fileName)
+
+		if fs.Exists(path) {
+			return parseConfig(path)
+		}
+	}
+
+	return nil, errors.Errorf("No config file found in %s. Expected filenames: %s", dir, configFileNameOptions)
+}
+
+func parseConfig(path string) (*GumConfig, error) {
+	log.Debugf("Parsing gum config file: %s", path)
+	config := &GumConfig{}
+
+	client := yaml.New()
+
+	if err := client.Read(path, config); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}

--- a/internal/homebrew/homebrew.go
+++ b/internal/homebrew/homebrew.go
@@ -1,0 +1,7 @@
+package homebrew
+
+type Package struct {
+	Name    string
+	Version string
+	Cask    bool
+}

--- a/internal/yaml/yaml.go
+++ b/internal/yaml/yaml.go
@@ -1,0 +1,64 @@
+package yaml
+
+import (
+	"os"
+	"reflect"
+
+	"github.com/pkg/errors"
+	"github.com/renegumroad/gum-cli/internal/filesystem"
+	lib "gopkg.in/yaml.v3"
+)
+
+type Client interface {
+	Read(path string, out interface{}) error
+	Load(data []byte, out interface{}) error
+}
+
+type client struct {
+	fs filesystem.Client
+}
+
+func New() Client {
+	return &client{
+		fs: filesystem.New(),
+	}
+}
+
+func (c *client) Read(path string, out interface{}) error {
+	if !c.fs.Exists(path) {
+		return errors.Errorf("File does not exist: %s", path)
+	}
+
+	if !c.fs.IsFile(path) {
+		return errors.Errorf("Path is not a file: %s", path)
+	}
+
+	bytes, err := os.ReadFile(path)
+
+	if err != nil {
+		return err
+	}
+
+	return c.Load(bytes, out)
+}
+
+func (c *client) Load(data []byte, out interface{}) error {
+	if data == nil {
+		return errors.Errorf("data argument is nil")
+	}
+
+	if out == nil {
+		return errors.Errorf("out argument is nil")
+	}
+
+	err := lib.Unmarshal(data, out)
+	if err != nil {
+		return errors.Errorf("Failed to unmarshal yaml: %s", err)
+	}
+
+	if out == nil || reflect.ValueOf(out).Elem().IsZero() {
+		return errors.Errorf("Unmarshalled yaml does not contain expected data: %v", out)
+	}
+
+	return nil
+}

--- a/internal/yaml/yaml_test.go
+++ b/internal/yaml/yaml_test.go
@@ -1,0 +1,114 @@
+package yaml
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type yamlSuite struct {
+	suite.Suite
+}
+
+func (s *yamlSuite) TestLoadValidYAML() {
+	type Config struct {
+		Name string `yaml:"name"`
+		Age  int    `yaml:"age"`
+	}
+	yamlData := []byte("name: John Doe\nage: 30")
+	expectedConfig := Config{Name: "John Doe", Age: 30}
+
+	var config Config
+	c := New()
+	err := c.Load(yamlData, &config)
+
+	s.Require().NoError(err)
+	s.Require().Equal(expectedConfig, config)
+}
+
+func (s *yamlSuite) TestLoadInvalidYAML() {
+	yamlData := []byte("name: John Doe\nage: thirty")
+
+	var config struct{}
+	c := New()
+	err := c.Load(yamlData, &config)
+
+	s.Require().Error(err)
+}
+
+func (s *yamlSuite) TestLoadNilPointer() {
+	yamlData := []byte("name: John Doe\nage: 30")
+	c := New()
+	err := c.Load(yamlData, nil)
+	s.Require().Error(err)
+}
+
+func (s *yamlSuite) TestReadValidYAMLFile() {
+	tmpFile, err := os.CreateTemp("", "valid*.yaml")
+	s.Require().NoError(err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("name: John Doe\nage: 30")
+	s.Require().NoError(err)
+	tmpFile.Close()
+
+	var config struct {
+		Name string `yaml:"name"`
+		Age  int    `yaml:"age"`
+	}
+	c := New()
+	err = c.Read(tmpFile.Name(), &config)
+	s.Require().NoError(err)
+	s.Require().Equal("John Doe", config.Name)
+	s.Require().Equal(30, config.Age)
+}
+
+func (s *yamlSuite) TestReadInvalidYAMLFile() {
+	tmpFile, err := os.CreateTemp("", "invalid*.yaml")
+	s.Require().NoError(err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("name: John Doe\nage: thirty")
+	s.Require().NoError(err)
+	tmpFile.Close()
+
+	var config struct{}
+	c := New()
+	err = c.Read(tmpFile.Name(), &config)
+	s.Require().Error(err)
+}
+
+func (s *yamlSuite) TestReadNonExistentFile() {
+	c := New()
+	err := c.Read("nonexistent.yaml", &struct{}{})
+	s.Require().Error(err)
+}
+
+func (s *yamlSuite) TestReadNilPointer() {
+	tmpFile, err := os.CreateTemp("", "valid*.yaml")
+	s.Require().NoError(err)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("name: John Doe\nage: 30")
+	s.Require().NoError(err)
+	tmpFile.Close()
+
+	c := New()
+	err = c.Read(tmpFile.Name(), nil)
+	s.Require().Error(err)
+}
+
+func (s *yamlSuite) TestReadDir() {
+	tmpDir, err := os.MkdirTemp("", "gum*")
+	s.Require().NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	c := New()
+	err = c.Read(tmpDir, nil)
+	s.Require().Error(err)
+}
+
+func TestYamlSuite(t *testing.T) {
+	suite.Run(t, new(yamlSuite))
+}


### PR DESCRIPTION
## Description

Add initial implementation for `gum dev up` command.

`dev up` commands handles configuring dependencies for your development environment (as of now local dependencies, but potentially cloud-based deps in the future). For this, it reads the `up:` block from a `gum.yml`/`gum.yaml` file and executes the required actions.

As part of this PR, we are handling parsing the config and validating that config. Follow-up PR will implement the required actions.

The definition for the `up` block is a follows:

```yaml
up:
  - action: <action_name>
  - brew:
    - name: <pkg>
    - name: <pkg>
      version: <version>
```

With the above def in mind, `dev up` can accept at this time 2 types of actions:
- named actions:  Declared in the form of `- action: <action_name` where there needs to be an action in code that matches the name (`actions.Exists` returns true)
- brew action: Will install any number of packages using brew. Can accept a particular package version and selectively install casks

## Implementation Details

- up internal implementation
- Add new yaml parsing package
- Add new gumconfig and `GumConfig` struct to manage `gum.yml` details
- New `actions` package `to host action implementations in subsequent PRs