### PR TITLE
Add new ruby action

### DIFF
--- a/internal/actions/action.go
+++ b/internal/actions/action.go
@@ -8,6 +8,7 @@ import (
 var (
 	namedActions = map[string]Action{
 		"golang": &GolangAction{},
+		"ruby":   &RubyAction{},
 	}
 )
 

--- a/internal/actions/ruby.go
+++ b/internal/actions/ruby.go
@@ -1,0 +1,35 @@
+package actions
+
+import (
+	"github.com/renegumroad/gum-cli/internal/cli/homebrew"
+	"github.com/renegumroad/gum-cli/internal/cli/rbenv"
+)
+
+type RubyAction struct{}
+
+func (a *RubyAction) Name() string {
+	return "ruby"
+}
+
+func (a *RubyAction) Public() bool {
+	return true
+}
+
+func (a *RubyAction) Deps() []Action {
+	return []Action{
+		NewBrewAction(
+			[]homebrew.Package{
+				{Name: "rbenv"},
+			}),
+	}
+}
+
+func (a *RubyAction) Validate() error {
+	return nil
+}
+
+func (a *RubyAction) Run() error {
+	client := rbenv.New()
+
+	return client.EnsureRubyInstalled()
+}

--- a/internal/cli/cmdexec/cmdexec.go
+++ b/internal/cli/cmdexec/cmdexec.go
@@ -88,6 +88,6 @@ func NewCommandGenerator() CmdGenerator {
 
 type EnvCmdGenerator func(cmd string, args, env []string) Command
 
-func EnvCommandGenerator() EnvCmdGenerator {
+func NewEnvCommandGenerator() EnvCmdGenerator {
 	return NewWithEnv
 }

--- a/internal/cli/homebrew/mockhomebrew/mock_client.go
+++ b/internal/cli/homebrew/mockhomebrew/mock_client.go
@@ -204,6 +204,52 @@ func (_c *MockClient_Link_Call) RunAndReturn(run func(homebrew.Package) error) *
 	return _c
 }
 
+// Upgrade provides a mock function with given fields: pkg
+func (_m *MockClient) Upgrade(pkg homebrew.Package) error {
+	ret := _m.Called(pkg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Upgrade")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(homebrew.Package) error); ok {
+		r0 = rf(pkg)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockClient_Upgrade_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Upgrade'
+type MockClient_Upgrade_Call struct {
+	*mock.Call
+}
+
+// Upgrade is a helper method to define mock.On call
+//   - pkg homebrew.Package
+func (_e *MockClient_Expecter) Upgrade(pkg interface{}) *MockClient_Upgrade_Call {
+	return &MockClient_Upgrade_Call{Call: _e.mock.On("Upgrade", pkg)}
+}
+
+func (_c *MockClient_Upgrade_Call) Run(run func(pkg homebrew.Package)) *MockClient_Upgrade_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(homebrew.Package))
+	})
+	return _c
+}
+
+func (_c *MockClient_Upgrade_Call) Return(_a0 error) *MockClient_Upgrade_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockClient_Upgrade_Call) RunAndReturn(run func(homebrew.Package) error) *MockClient_Upgrade_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockClient creates a new instance of MockClient. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockClient(t interface {

--- a/internal/cli/rbenv/rbenv.go
+++ b/internal/cli/rbenv/rbenv.go
@@ -1,0 +1,82 @@
+package rbenv
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/renegumroad/gum-cli/internal/cli/cmdexec"
+	"github.com/renegumroad/gum-cli/internal/cli/homebrew"
+	"github.com/renegumroad/gum-cli/internal/log"
+)
+
+type Client interface {
+	IsRubyInstalled() bool
+	EnsureRubyInstalled() error
+}
+
+type client struct {
+	cmdGen cmdexec.CmdGenerator
+	brew   homebrew.Client
+}
+
+func New() Client {
+	return newClientWithComponents(
+		cmdexec.NewCommandGenerator(),
+		homebrew.New(),
+	)
+}
+
+func newClientWithComponents(
+	gen cmdexec.CmdGenerator,
+	brew homebrew.Client,
+) Client {
+	return &client{
+		cmdGen: gen,
+		brew:   brew,
+	}
+}
+
+func (c *client) EnsureRubyInstalled() error {
+	if c.IsRubyInstalled() {
+		log.Infof("ruby version is already installed")
+		return nil
+	}
+
+	if err := c.updateRubyBuild(); err != nil {
+		return err
+	}
+
+	log.Infof("Installing ruby version")
+
+	cmd := c.cmdGen("rbenv", "install", "--skip-existing")
+	err := cmd.Run()
+
+	if err != nil {
+		return errors.Errorf("Failed ruby installation: %s", err)
+	}
+
+	return nil
+}
+
+func (c *client) IsRubyInstalled() bool {
+	log.Debugln("Checking ruby version")
+
+	cmd := c.cmdGen("rbenv", "version")
+	err := cmd.Run()
+	if err != nil {
+		log.Debugf("Failed to check ruby version: %s", err)
+		return false
+	}
+
+	return !strings.Contains(cmd.Stdout(), "not installed")
+}
+
+func (c *client) updateRubyBuild() error {
+	log.Infof("Updating ruby-build")
+
+	if err := c.brew.Upgrade(homebrew.Package{Name: "ruby-build"}); err != nil {
+		return errors.Errorf("Failed to update ruby-build: %s", err)
+	}
+
+	return nil
+}

--- a/internal/cli/rbenv/rbenv_test.go
+++ b/internal/cli/rbenv/rbenv_test.go
@@ -1,0 +1,101 @@
+package rbenv
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/renegumroad/gum-cli/internal/cli/cmdexec/fakecmdexec"
+	"github.com/renegumroad/gum-cli/internal/cli/homebrew"
+	"github.com/renegumroad/gum-cli/internal/cli/homebrew/mockhomebrew"
+	"github.com/renegumroad/gum-cli/internal/log"
+	"github.com/stretchr/testify/suite"
+)
+
+type rbenvSuite struct {
+	suite.Suite
+	mockBrew *mockhomebrew.MockClient
+}
+
+func (s *rbenvSuite) SetupSuite() {
+	err := log.Initialize(log.LogDisabled)
+	s.Require().NoError(err)
+}
+
+func (s *rbenvSuite) SetupTest() {
+	s.mockBrew = mockhomebrew.NewMockClient(s.T())
+}
+
+// TestIsRubyInstalled_Success
+func (s *rbenvSuite) TestIsRubyInstalledSuccess() {
+	rbenvCmd := fakecmdexec.NewNoOpCommandWithOutputs(&fakecmdexec.NoOpOutputs{
+		Stdout: "2.7.2 (set by path)",
+	})
+	client := newClientWithComponents(fakecmdexec.NewCmdGenerator(rbenvCmd), s.mockBrew)
+
+	result := client.IsRubyInstalled()
+
+	s.Require().True(result)
+	s.Require().Equal("rbenv", rbenvCmd.Cmd())
+	s.Require().Equal([]string{"version"}, rbenvCmd.Args())
+}
+
+func (s *rbenvSuite) TestIsRubyInstalledNotInstalled() {
+	rbenvCmd := fakecmdexec.NewNoOpCommandWithOutputs(&fakecmdexec.NoOpOutputs{
+		Stdout: "rbenv: version '2.7.2' is not installed (set by path)",
+	})
+	client := newClientWithComponents(fakecmdexec.NewCmdGenerator(rbenvCmd), s.mockBrew)
+
+	result := client.IsRubyInstalled()
+
+	s.Require().False(result)
+	s.Require().Equal("rbenv", rbenvCmd.Cmd())
+	s.Require().Equal([]string{"version"}, rbenvCmd.Args())
+}
+
+func (s *rbenvSuite) TestIsRubyInstalleErrorRunningCommand() {
+	rbenvCmd := fakecmdexec.NewNoOpCommandWithOutputs(&fakecmdexec.NoOpOutputs{
+		Err: errors.New("error running command"),
+	})
+	client := newClientWithComponents(fakecmdexec.NewCmdGenerator(rbenvCmd), s.mockBrew)
+
+	result := client.IsRubyInstalled()
+
+	s.Require().False(result)
+	s.Require().Equal("rbenv", rbenvCmd.Cmd())
+	s.Require().Equal([]string{"version"}, rbenvCmd.Args())
+}
+
+func (s *rbenvSuite) TestEnsureRubyInstalledAlreadyInstalled() {
+	rbenvCmdVersion := fakecmdexec.NewNoOpCommandWithOutputs(&fakecmdexec.NoOpOutputs{
+		Stdout: "2.7.2 (set by path)",
+	})
+	client := newClientWithComponents(fakecmdexec.NewCmdGenerator(rbenvCmdVersion), s.mockBrew)
+
+	err := client.EnsureRubyInstalled()
+
+	s.Require().NoError(err)
+	s.Require().Equal("rbenv", rbenvCmdVersion.Cmd())
+	s.Require().Equal([]string{"version"}, rbenvCmdVersion.Args())
+}
+
+func (s *rbenvSuite) TestEnsureRubyInstalledNotInstalled() {
+	rbenvCmdVersion := fakecmdexec.NewNoOpCommandWithOutputs(&fakecmdexec.NoOpOutputs{
+		Stdout: "2.7.2 not installed (set by path)",
+	})
+	rbenvInstallCmd := fakecmdexec.NewNoOpCommand()
+	s.mockBrew.EXPECT().Upgrade(homebrew.Package{Name: "ruby-build"}).Return(nil)
+	client := newClientWithComponents(fakecmdexec.NewCmdGenerator(rbenvCmdVersion, rbenvInstallCmd), s.mockBrew)
+
+	err := client.EnsureRubyInstalled()
+
+	s.Require().NoError(err)
+	s.Require().Equal("rbenv", rbenvCmdVersion.Cmd())
+	s.Require().Equal([]string{"version"}, rbenvCmdVersion.Args())
+	s.Require().Equal("rbenv", rbenvInstallCmd.Cmd())
+	s.Require().Equal([]string{"install", "--skip-existing"}, rbenvInstallCmd.Args())
+	s.mockBrew.AssertExpectations(s.T())
+}
+
+func TestRbenvSuite(t *testing.T) {
+	suite.Run(t, new(rbenvSuite))
+}


### PR DESCRIPTION
## Description

Add a new `ruby` action that can be declared in the `up` block in the gum.yml.

### Implementation details

- New `rbenv` client to abstract relevant `rbenv` cli operations
- Enhance fakecmdexec generators to accept a list of `NoOpCommand`s for methods that invoke multiple cli commands under the hood
- New `Upgrade` function in the homebrew client to handle package that require upgrades (e.g: `ruby-build`)

## Testing

Running `gum dev up` from a local build with a non-installed ruby version:

**gum.yml:**

```yaml
up:
  - action: ruby
```

**ruby version:**

```shell
❯ cat .ruby-version 
3.3.1
```

**First run with ruby version not installed:**

```shell
work/gumroad/rbenv-test[💎 v2.6.10]
❯ ../gum-cli/build/darwin_arm64/gum dev up --log-level debug
1:26PM debug: Logging initialized
1:26PM debug: Validating up command
1:26PM debug: Detecting gum config in /Users/renehernandez/work/gumroad/rbenv-test
1:26PM debug: Parsing gum config file: /Users/renehernandez/work/gumroad/rbenv-test/gum.yml
1:26PM debug: Validating gum config
1:26PM info: gum.yml config validated successfully
1:26PM debug: Validating action ruby
1:26PM debug: Validating dependent action brew
1:26PM debug: Dependent action brew validated
1:26PM debug: Action ruby validated
1:26PM info: 1 action(s) validated successfully
1:26PM debug: Running up command
1:26PM info: Running action ruby
1:26PM debug: Running dependent action brew
1:26PM info: Ensuring package rbenv is installed
1:26PM info: Brew package rbenv is already installed
1:26PM debug: Dependent action brew ran successfully
1:26PM debug: Checking ruby version
1:26PM debug: Running command: rbenv [version] with env: []
1:26PM debug: Cmd execution stdout: 
1:26PM debug: Cmd execution stderr: rbenv: version `3.3.1' is not installed (set by /Users/renehernandez/work/gumroad/rbenv-test/.ruby-version)

1:26PM debug: Failed to check ruby version: exit status 1
1:26PM info: Updating ruby-build
1:26PM debug: Upgrading brew package ruby-build
1:26PM debug: Running command: brew [upgrade ruby-build] with env: [HOMEBREW_NO_INSTALL_CLEANUP=1]
1:26PM info: Installing ruby version
1:26PM debug: Running command: rbenv [install --skip-existing] with env: []
1:29PM info: Action ruby ran successfully
```

**2nd run with the ruby version already installed:**

```shell
work/gumroad/rbenv-test[💎 v2.6.10]
❯ ../gum-cli/build/darwin_arm64/gum dev up --log-level debug
1:32PM debug: Logging initialized
1:32PM debug: Validating up command
1:32PM debug: Detecting gum config in /Users/renehernandez/work/gumroad/rbenv-test
1:32PM debug: Parsing gum config file: /Users/renehernandez/work/gumroad/rbenv-test/gum.yml
1:32PM debug: Validating gum config
1:32PM info: gum.yml config validated successfully
1:32PM debug: Validating action ruby
1:32PM debug: Validating dependent action brew
1:32PM debug: Dependent action brew validated
1:32PM debug: Action ruby validated
1:32PM info: 1 action(s) validated successfully
1:32PM debug: Running up command
1:32PM info: Running action ruby
1:32PM debug: Running dependent action brew
1:32PM info: Ensuring package rbenv is installed
1:32PM info: Brew package rbenv is already installed
1:32PM debug: Dependent action brew ran successfully
1:32PM debug: Checking ruby version
1:32PM debug: Running command: rbenv [version] with env: []
1:32PM info: ruby version is already installed
1:32PM info: Action ruby ran successfully
```
