### PR TITLE
Expand ruby action to handle bundler actions

### DIFF
--- a/internal/actions/ruby.go
+++ b/internal/actions/ruby.go
@@ -1,6 +1,7 @@
 package actions
 
 import (
+	"github.com/renegumroad/gum-cli/internal/cli/bundler"
 	"github.com/renegumroad/gum-cli/internal/cli/homebrew"
 	"github.com/renegumroad/gum-cli/internal/cli/rbenv"
 	"github.com/renegumroad/gum-cli/internal/systeminfo"
@@ -43,11 +44,25 @@ func (a *RubyAction) Validate() error {
 }
 
 func (a *RubyAction) ShouldRun() bool {
-	return depsShouldRun(a.Deps())
+	return true
 }
 
 func (a *RubyAction) Run() error {
-	client := rbenv.New()
+	rbClient := rbenv.New()
 
-	return client.EnsureRubyInstalled()
+	if err := rbClient.EnsureRubyInstalled(); err != nil {
+		return err
+	}
+
+	bundClient := bundler.New()
+
+	if err := bundClient.EnsureBundlerInstalled(); err != nil {
+		return err
+	}
+
+	if err := bundClient.InstallGems(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/cli/bundler/bundler.go
+++ b/internal/cli/bundler/bundler.go
@@ -1,0 +1,188 @@
+package bundler
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/renegumroad/gum-cli/internal/cli/cmdexec"
+	"github.com/renegumroad/gum-cli/internal/filesystem"
+	"github.com/renegumroad/gum-cli/internal/log"
+)
+
+type Client interface {
+	InstallGems() error
+	InstallBundler() error
+	IsBundlerInstalled() bool
+	EnsureBundlerInstalled() error
+}
+
+type client struct {
+	dir    string
+	fs     filesystem.Client
+	cmdGen cmdexec.CmdGenerator
+}
+
+func New() Client {
+	return newClientWithComponents(
+		filesystem.New(),
+		cmdexec.NewCommandGenerator(),
+	)
+}
+
+func newClientWithComponents(
+	fs filesystem.Client,
+	cmdGen cmdexec.CmdGenerator,
+) *client {
+	return &client{
+		fs:     fs,
+		cmdGen: cmdGen,
+	}
+}
+
+func (c *client) InstallGems() error {
+	log.Debugf("Installing gems with Bundler")
+	dir, err := c.fs.CurrentDir()
+	if err != nil {
+		return err
+	}
+	gemfile := filepath.Join(dir, "Gemfile")
+
+	if !c.fs.Exists(gemfile) {
+		return errors.Errorf("Gemfile not found in %s", c.dir)
+	}
+
+	log.Infof("Running bundle install")
+	cmd := c.cmdGen("bundle", "install")
+
+	if err := cmd.Run(); err != nil {
+		return errors.Errorf("Failed to install gems: err: %s; stdout: %s; stderr: %s", err, cmd.Stdout(), cmd.Stderr())
+	}
+
+	return nil
+}
+
+func (c *client) EnsureBundlerInstalled() error {
+	if c.IsBundlerInstalled() {
+		log.Infof("Bundler is already installed")
+		return nil
+	}
+
+	if err := c.InstallBundler(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *client) IsBundlerInstalled() bool {
+	version := c.getBundlerVersion()
+
+	if version == "" {
+		log.Debugf("No bundler version found. Bundler will use the default version")
+		return true
+	}
+
+	cmd := c.cmdGen("gem", "list", "--installed", "--exact", "bundler", "--version", version)
+
+	if err := cmd.Run(); err != nil {
+		return false
+	}
+
+	return strings.EqualFold(cmd.Stdout(), "true")
+}
+
+func (c *client) InstallBundler() error {
+	version := c.getBundlerVersion()
+
+	if version == "" {
+		log.Debugf("No bundler version found. Using default version")
+		return nil
+	}
+
+	log.Infof("Installing Bundler version %s", version)
+
+	cmd := c.cmdGen("gem", "install", fmt.Sprintf("bundler:%s", version))
+
+	if err := cmd.Run(); err != nil {
+		return errors.Errorf("Failed to install bundler gem: %s", err)
+	}
+
+	return nil
+}
+
+func (c *client) getBundlerVersion() string {
+	version, err := c.getVersionFromVersionFile()
+
+	if err != nil {
+		version, _ = c.getVersionFromGemfileLock()
+	}
+
+	return version
+}
+
+func (c *client) getVersionFromVersionFile() (string, error) {
+	dir, err := c.fs.CurrentDir()
+	if err != nil {
+		return "", err
+	}
+	bundlerVersionFile := filepath.Join(dir, ".bundler-version")
+	log.Debugf("Checking for Bundler version in %s", bundlerVersionFile)
+
+	if !c.fs.Exists(bundlerVersionFile) {
+		return "", nil
+	}
+
+	content, err := c.fs.ReadString(bundlerVersionFile)
+	if err != nil {
+		return "", err
+	}
+
+	if content == "" {
+		return "", errors.Errorf("Bundler version not found in .bundler-version file")
+	}
+
+	re := regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+	match := re.MatchString(content)
+
+	if !match {
+		return "", errors.Errorf("Invalid Bundler version in .bundler-version file")
+	}
+
+	return content, nil
+}
+
+func (c *client) getVersionFromGemfileLock() (string, error) {
+	dir, err := c.fs.CurrentDir()
+	if err != nil {
+		return "", err
+	}
+	gemfileLock := filepath.Join(dir, "Gemfile.lock")
+	log.Debugf("Checking for Bundler version in %s", gemfileLock)
+
+	if !c.fs.Exists(gemfileLock) {
+		return "", nil
+	}
+
+	content, err := c.fs.ReadString(gemfileLock)
+	if err != nil {
+		return "", err
+	}
+
+	// Define a regular expression to find the Bundler version
+	// The version is expected to be in the format of `BUNDLED WITH` followed by the version number
+	re := regexp.MustCompile(`BUNDLED WITH\s+(\d+\.\d+\.\d+)`)
+
+	// Find the version using the regular expression
+	matches := re.FindStringSubmatch(content)
+
+	// Check if a version was found
+	if len(matches) < 2 {
+		return "", errors.Errorf("Bundler version not found in Gemfile.lock")
+	}
+
+	return matches[1], nil
+}

--- a/internal/cli/bundler/bundler_test.go
+++ b/internal/cli/bundler/bundler_test.go
@@ -37,99 +37,99 @@ func (s *bundlerSuite) TestGetVersionFromVersionFileExistsWithValidVersion() {
 }
 
 func (s *bundlerSuite) TestGetVersionFromVersionFileNotExists() {
-  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
-  s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(false)
+	s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+	s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(false)
 
-  client := newClientWithComponents(s.mockFs, nil)
+	client := newClientWithComponents(s.mockFs, nil)
 
-  version, err := client.getVersionFromVersionFile()
+	version, err := client.getVersionFromVersionFile()
 
-  s.Require().NoError(err)
-  s.Equal("", version)
-  s.mockFs.AssertExpectations(s.T())
+	s.Require().NoError(err)
+	s.Equal("", version)
+	s.mockFs.AssertExpectations(s.T())
 }
 
 func (s *bundlerSuite) TestGetVersionFromVersionFileExistsWithInvalidVersion() {
-  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
-  s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(true)
-  s.mockFs.On("ReadString", "/test/dir/.bundler-version").Return("invalid_version", nil)
+	s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+	s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(true)
+	s.mockFs.On("ReadString", "/test/dir/.bundler-version").Return("invalid_version", nil)
 
-  client := newClientWithComponents(s.mockFs, nil)
+	client := newClientWithComponents(s.mockFs, nil)
 
-  version, err := client.getVersionFromVersionFile()
+	version, err := client.getVersionFromVersionFile()
 
-  s.Require().Error(err)
-  s.Equal("", version)
-  s.mockFs.AssertExpectations(s.T())
+	s.Require().Error(err)
+	s.Equal("", version)
+	s.mockFs.AssertExpectations(s.T())
 }
 
 func (s *bundlerSuite) TestGetVersionFromVersionFileExistsWithEmptyVersion() {
-  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
-  s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(true)
-  s.mockFs.On("ReadString", "/test/dir/.bundler-version").Return("", nil)
+	s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+	s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(true)
+	s.mockFs.On("ReadString", "/test/dir/.bundler-version").Return("", nil)
 
-  client := newClientWithComponents(s.mockFs, nil)
+	client := newClientWithComponents(s.mockFs, nil)
 
-  version, err := client.getVersionFromVersionFile()
+	version, err := client.getVersionFromVersionFile()
 
-  s.Require().Error(err)
-  s.Equal("", version)
-  s.mockFs.AssertExpectations(s.T())
+	s.Require().Error(err)
+	s.Equal("", version)
+	s.mockFs.AssertExpectations(s.T())
 }
 
 func (s *bundlerSuite) TestGetVersionFromGemfileLockExistsWithValidVersion() {
-  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
-  s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
-  s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("BUNDLED WITH\n   2.1.4", nil)
+	s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+	s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
+	s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("BUNDLED WITH\n   2.1.4", nil)
 
-  client := newClientWithComponents(s.mockFs, nil)
+	client := newClientWithComponents(s.mockFs, nil)
 
-  version, err := client.getVersionFromGemfileLock()
+	version, err := client.getVersionFromGemfileLock()
 
-  s.Require().NoError(err)
-  s.Equal("2.1.4", version)
-  s.mockFs.AssertExpectations(s.T())
+	s.Require().NoError(err)
+	s.Equal("2.1.4", version)
+	s.mockFs.AssertExpectations(s.T())
 }
 
 func (s *bundlerSuite) TestGetVersionFromGemfileLockNotExists() {
-  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
-  s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(false)
+	s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+	s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(false)
 
-  client := newClientWithComponents(s.mockFs, nil)
+	client := newClientWithComponents(s.mockFs, nil)
 
-  version, err := client.getVersionFromGemfileLock()
+	version, err := client.getVersionFromGemfileLock()
 
-  s.Require().NoError(err)
-  s.Equal("", version)
-  s.mockFs.AssertExpectations(s.T())
+	s.Require().NoError(err)
+	s.Equal("", version)
+	s.mockFs.AssertExpectations(s.T())
 }
 
 func (s *bundlerSuite) TestGetVersionFromGemfileLockExistsWithInvalidVersion() {
-  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
-  s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
-  s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("BUNDLED WITH\n   invalid_version", nil)
+	s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+	s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
+	s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("BUNDLED WITH\n   invalid_version", nil)
 
-  client := newClientWithComponents(s.mockFs, nil)
+	client := newClientWithComponents(s.mockFs, nil)
 
-  version, err := client.getVersionFromGemfileLock()
+	version, err := client.getVersionFromGemfileLock()
 
-  s.Require().Error(err)
-  s.Equal("", version)
-  s.mockFs.AssertExpectations(s.T())
+	s.Require().Error(err)
+	s.Equal("", version)
+	s.mockFs.AssertExpectations(s.T())
 }
 
 func (s *bundlerSuite) TestGetVersionFromGemfileLockExistsWithEmptyVersion() {
-  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
-  s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
-  s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("", nil)
+	s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+	s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
+	s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("", nil)
 
-  client := newClientWithComponents(s.mockFs, nil)
+	client := newClientWithComponents(s.mockFs, nil)
 
-  version, err := client.getVersionFromGemfileLock()
+	version, err := client.getVersionFromGemfileLock()
 
-  s.Require().Error(err)
-  s.Equal("", version)
-  s.mockFs.AssertExpectations(s.T())
+	s.Require().Error(err)
+	s.Equal("", version)
+	s.mockFs.AssertExpectations(s.T())
 }
 
 func TestBundlerSuite(t *testing.T) {

--- a/internal/cli/bundler/bundler_test.go
+++ b/internal/cli/bundler/bundler_test.go
@@ -1,0 +1,137 @@
+package bundler
+
+import (
+	"testing"
+
+	"github.com/renegumroad/gum-cli/internal/filesystem/mockfilesystem"
+	"github.com/renegumroad/gum-cli/internal/log"
+	"github.com/stretchr/testify/suite"
+)
+
+type bundlerSuite struct {
+	suite.Suite
+	mockFs *mockfilesystem.MockClient
+}
+
+func (s *bundlerSuite) SetupSuite() {
+	err := log.Initialize(log.LogDisabled)
+	s.Require().NoError(err)
+}
+
+func (s *bundlerSuite) SetupTest() {
+	s.mockFs = mockfilesystem.NewMockClient(s.T())
+}
+
+func (s *bundlerSuite) TestGetVersionFromVersionFileExistsWithValidVersion() {
+	s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+	s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(true)
+	s.mockFs.On("ReadString", "/test/dir/.bundler-version").Return("2.1.4", nil)
+
+	client := newClientWithComponents(s.mockFs, nil)
+
+	version, err := client.getVersionFromVersionFile()
+
+	s.Require().NoError(err)
+	s.Equal("2.1.4", version)
+	s.mockFs.AssertExpectations(s.T())
+}
+
+func (s *bundlerSuite) TestGetVersionFromVersionFileNotExists() {
+  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+  s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(false)
+
+  client := newClientWithComponents(s.mockFs, nil)
+
+  version, err := client.getVersionFromVersionFile()
+
+  s.Require().NoError(err)
+  s.Equal("", version)
+  s.mockFs.AssertExpectations(s.T())
+}
+
+func (s *bundlerSuite) TestGetVersionFromVersionFileExistsWithInvalidVersion() {
+  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+  s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(true)
+  s.mockFs.On("ReadString", "/test/dir/.bundler-version").Return("invalid_version", nil)
+
+  client := newClientWithComponents(s.mockFs, nil)
+
+  version, err := client.getVersionFromVersionFile()
+
+  s.Require().Error(err)
+  s.Equal("", version)
+  s.mockFs.AssertExpectations(s.T())
+}
+
+func (s *bundlerSuite) TestGetVersionFromVersionFileExistsWithEmptyVersion() {
+  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+  s.mockFs.On("Exists", "/test/dir/.bundler-version").Return(true)
+  s.mockFs.On("ReadString", "/test/dir/.bundler-version").Return("", nil)
+
+  client := newClientWithComponents(s.mockFs, nil)
+
+  version, err := client.getVersionFromVersionFile()
+
+  s.Require().Error(err)
+  s.Equal("", version)
+  s.mockFs.AssertExpectations(s.T())
+}
+
+func (s *bundlerSuite) TestGetVersionFromGemfileLockExistsWithValidVersion() {
+  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+  s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
+  s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("BUNDLED WITH\n   2.1.4", nil)
+
+  client := newClientWithComponents(s.mockFs, nil)
+
+  version, err := client.getVersionFromGemfileLock()
+
+  s.Require().NoError(err)
+  s.Equal("2.1.4", version)
+  s.mockFs.AssertExpectations(s.T())
+}
+
+func (s *bundlerSuite) TestGetVersionFromGemfileLockNotExists() {
+  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+  s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(false)
+
+  client := newClientWithComponents(s.mockFs, nil)
+
+  version, err := client.getVersionFromGemfileLock()
+
+  s.Require().NoError(err)
+  s.Equal("", version)
+  s.mockFs.AssertExpectations(s.T())
+}
+
+func (s *bundlerSuite) TestGetVersionFromGemfileLockExistsWithInvalidVersion() {
+  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+  s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
+  s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("BUNDLED WITH\n   invalid_version", nil)
+
+  client := newClientWithComponents(s.mockFs, nil)
+
+  version, err := client.getVersionFromGemfileLock()
+
+  s.Require().Error(err)
+  s.Equal("", version)
+  s.mockFs.AssertExpectations(s.T())
+}
+
+func (s *bundlerSuite) TestGetVersionFromGemfileLockExistsWithEmptyVersion() {
+  s.mockFs.On("CurrentDir").Return("/test/dir", nil)
+  s.mockFs.On("Exists", "/test/dir/Gemfile.lock").Return(true)
+  s.mockFs.On("ReadString", "/test/dir/Gemfile.lock").Return("", nil)
+
+  client := newClientWithComponents(s.mockFs, nil)
+
+  version, err := client.getVersionFromGemfileLock()
+
+  s.Require().Error(err)
+  s.Equal("", version)
+  s.mockFs.AssertExpectations(s.T())
+}
+
+func TestBundlerSuite(t *testing.T) {
+	suite.Run(t, new(bundlerSuite))
+}

--- a/internal/cli/rbenv/rbenv.go
+++ b/internal/cli/rbenv/rbenv.go
@@ -38,7 +38,7 @@ func newClientWithComponents(
 
 func (c *client) EnsureRubyInstalled() error {
 	if c.IsRubyInstalled() {
-		log.Infof("ruby version is already installed")
+		log.Infof("Ruby version is already installed")
 		return nil
 	}
 

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -35,6 +35,7 @@ type Client interface {
 	WriteString(path, content string) error
 	AppendString(path, content string) error
 	MkdirAll(path string) error
+  ReadString(path string) (string, error)
 }
 
 type UserInfo struct {
@@ -310,4 +311,13 @@ func (c *client) MkdirAll(path string) error {
 		return errors.Errorf("Path %s exists and is not a directory", path)
 	}
 	return os.MkdirAll(path, os.ModePerm)
+}
+
+func (c *client) ReadString(path string) (string, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
 }

--- a/internal/filesystem/filesystem.go
+++ b/internal/filesystem/filesystem.go
@@ -35,7 +35,7 @@ type Client interface {
 	WriteString(path, content string) error
 	AppendString(path, content string) error
 	MkdirAll(path string) error
-  ReadString(path string) (string, error)
+	ReadString(path string) (string, error)
 }
 
 type UserInfo struct {

--- a/internal/filesystem/mockfilesystem/mock_client.go
+++ b/internal/filesystem/mockfilesystem/mock_client.go
@@ -857,6 +857,62 @@ func (_c *MockClient_MkdirTemp_Call) RunAndReturn(run func() (string, error)) *M
 	return _c
 }
 
+// ReadString provides a mock function with given fields: path
+func (_m *MockClient) ReadString(path string) (string, error) {
+	ret := _m.Called(path)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReadString")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (string, error)); ok {
+		return rf(path)
+	}
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(path)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(path)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockClient_ReadString_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReadString'
+type MockClient_ReadString_Call struct {
+	*mock.Call
+}
+
+// ReadString is a helper method to define mock.On call
+//   - path string
+func (_e *MockClient_Expecter) ReadString(path interface{}) *MockClient_ReadString_Call {
+	return &MockClient_ReadString_Call{Call: _e.mock.On("ReadString", path)}
+}
+
+func (_c *MockClient_ReadString_Call) Run(run func(path string)) *MockClient_ReadString_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockClient_ReadString_Call) Return(_a0 string, _a1 error) *MockClient_ReadString_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockClient_ReadString_Call) RunAndReturn(run func(string) (string, error)) *MockClient_ReadString_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RootDir provides a mock function with given fields:
 func (_m *MockClient) RootDir() string {
 	ret := _m.Called()


### PR DESCRIPTION
## Description

Expand the ruby action to also handle correct bundler version installation and execute `bundler install` whenever there is a `Gemfile

### Implementation details

- New `bundler` cli implementation that handles installing bundler itself (a particular version either declared in `.bundler-version` or `Gemfile.lock`) and install gems
- New `ReadString` method in the filesystem client to simplify getting file content as a string


## Testing

Running a local `gum` build:

**Failed bundle install (incompatible versions dependencies):**

Gemfile: 

```
# frozen_string_literal: true

source "https://rubygems.org"

# Specify your gem's dependencies in rbocf.gemspec
gemspec

gem "rake", "~> 13.0"

gem "minitest", "~> 5.16"

gem "standard", "~> 1.3"

gem "rubocop", "~> 0.89"
````

```shell
work/gumroad/rbocf[ main][!?][💎 v3.3.2][⏱ 2s]
❯ ../gum-cli/build/darwin_arm64/gum dev up
11:28AM info: gum.yml config validated successfully
11:28AM info: 5 action(s) validated successfully
11:28AM info: Skipping action xcode
11:28AM info: Skipping action script
11:28AM info: Skipping action brew_ensure
11:28AM info: Skipping action brew
11:28AM info: Running action ruby
11:28AM info: Ruby version is already installed
11:28AM info: Bundler is already installed
11:28AM info: Running bundle install
11:28AM error: Action ruby run failed: Failed to install gems: err: exit status 6; stdout: Fetching gem metadata from https://rubygems.org/...........
Resolving dependencies...
; stderr: Could not find compatible versions

Because standard >= 1.37.0 depends on rubocop ~> 1.64.0
  and standard >= 1.36.0, < 1.37.0 depends on rubocop ~> 1.63.0,
  standard >= 1.36.0 requires rubocop ~> 1.63.0 OR ~> 1.64.0.
And because standard >= 1.35.1, < 1.36.0 depends on rubocop ~> 1.62.0
  and standard >= 1.35.0, < 1.35.1 depends on rubocop ~> 1.62,
  standard >= 1.35.0 requires rubocop >= 1.62.0, < 2.A.
....
OR = 1.15.2 OR >= 1.16.0, < 1.17.A.
And because standard >= 1.2.0, < 1.5.0 depends on rubocop-performance = 1.11.5
and rubocop-performance >= 1.11.0, < 1.20.0 depends on rubocop >= 1.7.0, <
2.0,
  standard >= 1.2.0 requires rubocop >= 1.7.0, < 2.0.
So, because Gemfile depends on standard ~> 1.3
  and Gemfile depends on rubocop ~> 0.89,
  version solving has failed.
```

**Bundle install successful:**

After fixing the `Gemfile` above by removing the incompatible `rubocop` gem:

```shell
work/gumroad/rbocf[ main][!?][💎 v3.3.2]
❯ ../gum-cli/build/darwin_arm64/gum dev up
11:28AM info: gum.yml config validated successfully
11:28AM info: 5 action(s) validated successfully
11:28AM info: Skipping action xcode
11:28AM info: Skipping action script
11:28AM info: Skipping action brew_ensure
11:28AM info: Skipping action brew
11:28AM info: Running action ruby
11:28AM info: Ruby version is already installed
11:28AM info: Bundler is already installed
11:28AM info: Running bundle install
11:28AM info: Action ruby ran successfully
```